### PR TITLE
Update save.mcfunction

### DIFF
--- a/data/rx/functions/player/save.mcfunction
+++ b/data/rx/functions/player/save.mcfunction
@@ -6,5 +6,4 @@
 execute if data storage rx:output root.player run data modify storage rx:output root.leftover append from storage rx:output root.player
 data modify storage rx:global root.players set from storage rx:output root.leftover
 
-data modify storage rx:output root.leftover set value {}
-data modify storage rx:output root.player set value {}
+data modify storage rx:output root set value {}


### PR DESCRIPTION
2nd `function rx:player/save` execution doesn't work because `leftover` isn't an array after 1st `function rx:player/save` execution.